### PR TITLE
Adjust overlay size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
     height:102vh;             /* cover notch bounce */
     transform:translateZ(0);  /* GPU kick */
   }
+  .overlay {
+    height: 50px !important;
+    width: 100vw !important;
+  }
 }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak mobile media query to update `.overlay` height and width

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68538eef14d08321a6309e763cba0ea2